### PR TITLE
Add per-sample MultiQC and compact process config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ All notable changes to the Daytona pipeline will be documented in this file.
 Full rebuild of the legacy `flaq_sc2_humanclean2.nf` SARS-CoV-2 pipeline into the
 BPHL GitHub SOP format.
 
+Later additions:
+
+- Per-sample MultiQC (`multiqc_sample`) over each sample's raw + clean FastQC, published to
+  `output/<sample_id>/multiqc/`; the aggregate MultiQC output dir renamed to
+  `output/all_multiqc/` and now runs with `--ignore "*/multiqc/*" --ignore "*/all_multiqc/*"`
+  so it no longer re-ingests MultiQC report/data dirs
+- `nextflow.config` compacted with regex `withName` selectors (`fastqc.*`, `bbtools.*`,
+  `samtools.*`, `ivar.*`)
+
 ### Added
 
 - `daytona.nf` — entry workflow; `meta`-driven, staged-file channel design replacing the

--- a/README.md
+++ b/README.md
@@ -117,12 +117,15 @@ flowchart TD
     V --> G[MULTIQC<br/>Aggregate QC Report]
     B --> G
     F --> G
+    B --> SM[MULTIQC<br/>Per-sample: Raw + Clean FastQC]
+    F --> SM
 
     style A fill:#e1f5e1,color:#000
     style S fill:#fff4e1,color:#000
     style V fill:#e1e5ff,color:#000,stroke-width:2px
     style W fill:#e1f5e1,color:#000,stroke-width:2px
     style G fill:#e1e5ff,color:#000,stroke-width:2px
+    style SM fill:#e1e5ff,color:#000
 ```
 
 > **QC GATE vs. assembly validation:** The **QC GATE** (`qc_flag`) is a minimum genome-breadth and read-depth check (≥80% genome covered, mean depth ≥100×) that gates **only VADR** (GenBank submission needs a complete genome). Pangolin and Nextclade run on **every** consensus, so a below-threshold genome still reports a lineage, clade, and SOTC — it just carries `qc_flag = FAIL` and `vadr_flag = FAIL`. Genome **assembly QC is performed by VADR**: a VADR **PASS** (`vadr_flag`) marks a submission-ready consensus, which is collected in `assemblies_qc_pass/`.
@@ -133,7 +136,7 @@ Daytona is made possible thanks to the following tools:
 
 <small>
 
-**Quality Control**: [FastQC](https://github.com/s-andrews/FastQC) 0.12.1 · [Trimmomatic](https://github.com/usadellab/Trimmomatic) 0.40 · [BBTools](https://github.com/bbushnell/BBTools) 39.84 · [MultiQC](https://github.com/MultiQC/MultiQC) 1.34
+**Quality Control**: [FastQC](https://github.com/s-andrews/FastQC) 0.12.1 · [Trimmomatic](https://github.com/usadellab/Trimmomatic) 0.40 · [BBTools](https://github.com/bbushnell/BBTools) 39.84 · [MultiQC](https://github.com/MultiQC/MultiQC) 1.34 (aggregate + per-sample)
 
 **Human Read Removal**: [NCBI SRA Human Scrubber](https://github.com/ncbi/sra-human-scrubber) 2.2.1
 
@@ -166,15 +169,18 @@ output/
 │   ├── ivar/
 │   ├── vadr/
 │   ├── pangolin/
-│   └── nextclade/
+│   ├── nextclade/
+│   └── multiqc/          # per-sample MultiQC (raw + clean FastQC)
 ├── assemblies_qc_pass/
-├── multiqc/
+├── all_multiqc/          # aggregate MultiQC across all samples
 └── summary_report.txt
 ```
 
 | File | Samples | Key fields |
 |------|---------|------------|
 | `summary_report.txt` | All | sample_id · reference · coverage stats · assembly stats · vadr_flag · qc_flag · pangolin_version · lineage · SOTC · kraken2_percent · nextclade_clade · nextclade_version |
+| `all_multiqc/multiqc_report.html` | All | Aggregate QC across all samples |
+| `<sample_id>/multiqc/<sample_id>_multiqc_report.html` | Per sample | Raw + clean FastQC for that sample |
 
 ### 🤝 Contributing
 

--- a/daytona.nf
+++ b/daytona.nf
@@ -28,7 +28,7 @@ include { vadr                           } from './modules/vadr.nf'
 include { pangolin                       } from './modules/pangolin.nf'
 include { nextclade_download; nextclade  } from './modules/nextclade.nf'
 include { summary_report                 } from './modules/summary_report.nf'
-include { multiqc                        } from './modules/multiqc.nf'
+include { multiqc; multiqc_sample        } from './modules/multiqc.nf'
 
 def refFiles() {
     def fa = "${projectDir}/assets/reference/nCoV-2019.reference.fasta"
@@ -74,6 +74,17 @@ workflow {
     bbtools_adapters(trimmomatic.out.reads)
     bbtools_phix(bbtools_adapters.out.reads)
     fastqc_clean(bbtools_phix.out.reads)
+
+    // Per-sample MultiQC over this sample's raw + clean FastQC
+    ch_sample_fastqc = fastqc.out.zip
+        .map { meta, zips -> [ meta.id, meta, zips ] }
+        .join( fastqc_clean.out.zip.map { meta, zips -> [ meta.id, zips ] } )
+        .map { _id, meta, raw, clean ->
+            def raw_list   = raw   instanceof List ? raw   : [raw]
+            def clean_list = clean instanceof List ? clean : [clean]
+            [ meta, raw_list + clean_list ]
+        }
+    multiqc_sample(ch_sample_fastqc)
 
     // Taxonomic screen
     kraken2(bbtools_phix.out.reads)

--- a/modules/multiqc.nf
+++ b/modules/multiqc.nf
@@ -1,6 +1,6 @@
 process multiqc {
     tag "multiqc"
-    publishDir "${params.output}/multiqc", mode: 'copy'
+    publishDir "${params.output}/all_multiqc", mode: 'copy'
 
     input:
         path summary
@@ -10,6 +10,23 @@ process multiqc {
 
     script:
     """
-    multiqc ${params.output} --interactive
+    multiqc ${params.output} --interactive --ignore "*/multiqc/*" --ignore "*/all_multiqc/*"
+    """
+}
+
+process multiqc_sample {
+    tag "${meta.id}"
+    publishDir "${params.output}/${meta.id}/multiqc", mode: 'copy'
+
+    input:
+        tuple val(meta), path(fastqc_zips)
+    output:
+        tuple val(meta), path("${meta.id}_multiqc_report.html"), emit: report
+        tuple val(meta), path("${meta.id}_multiqc_report_data"), emit: data
+
+    script:
+    def prefix = meta.id
+    """
+    multiqc . --interactive --filename ${prefix}_multiqc_report
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,14 +4,9 @@ params {
     sotc          = "S:L452R,S:E484K"     // comma-separated spike mutations to screen
 }
 
-// Process-specific configs — container, cpus, memory per tool
+// Process-specific configs: container, cpus, memory per tool.
 process {
-    withName: fastqc {
-        container = 'docker://staphb/fastqc:0.12.1'
-        cpus      = 2
-        memory    = 4.GB
-    }
-    withName: fastqc_clean {
+    withName: 'fastqc.*' {
         container = 'docker://staphb/fastqc:0.12.1'
         cpus      = 2
         memory    = 4.GB
@@ -26,12 +21,7 @@ process {
         cpus      = 4
         memory    = 8.GB
     }
-    withName: bbtools_adapters {
-        container = 'docker://staphb/bbtools:39.84'
-        cpus      = 4
-        memory    = 8.GB
-    }
-    withName: bbtools_phix {
+    withName: 'bbtools.*' {
         container = 'docker://staphb/bbtools:39.84'
         cpus      = 4
         memory    = 8.GB
@@ -46,37 +36,13 @@ process {
         cpus      = 8
         memory    = 16.GB
     }
-    withName: samtools_bam {
+    withName: 'samtools.*' {
         container     = 'docker://staphb/samtools:1.23.1'
         cpus          = 4
         memory        = 8.GB
         errorStrategy = 'ignore'
     }
-    withName: samtools_coverage {
-        container     = 'docker://staphb/samtools:1.23.1'
-        cpus          = 4
-        memory        = 8.GB
-        errorStrategy = 'ignore'
-    }
-    withName: samtools_mpileup {
-        container     = 'docker://staphb/samtools:1.23.1'
-        cpus          = 4
-        memory        = 8.GB
-        errorStrategy = 'ignore'
-    }
-    withName: ivar_trim {
-        container     = 'docker://staphb/ivar:1.4.4'
-        cpus          = 4
-        memory        = 8.GB
-        errorStrategy = 'ignore'
-    }
-    withName: ivar_variants {
-        container     = 'docker://staphb/ivar:1.4.4'
-        cpus          = 4
-        memory        = 8.GB
-        errorStrategy = 'ignore'
-    }
-    withName: ivar_consensus {
+    withName: 'ivar.*' {
         container     = 'docker://staphb/ivar:1.4.4'
         cpus          = 4
         memory        = 8.GB
@@ -118,6 +84,12 @@ process {
         container = 'docker://staphb/multiqc:1.34'
         cpus      = 2
         memory    = 4.GB
+    }
+    withName: multiqc_sample {
+        container     = 'docker://staphb/multiqc:1.34'
+        cpus          = 2
+        memory        = 4.GB
+        errorStrategy = 'ignore'
     }
 }
 


### PR DESCRIPTION
- Add multiqc_sample: per-sample MultiQC over raw + clean FastQC (output/<sample_id>/multiqc/)
- Rename aggregate MultiQC output to output/all_multiqc/; aggregate --ignores MultiQC report/data dirs
- Compact nextflow.config with regex withName selectors (fastqc.*, bbtools.*, samtools.*, ivar.*)
- Update README and CHANGELOG